### PR TITLE
Fix other tile sizes

### DIFF
--- a/Source/RTS/Plugins/RTSPlugin/Source/RTSPlugin/Private/RTSFogOfWarActor.cpp
+++ b/Source/RTS/Plugins/RTSPlugin/Source/RTSPlugin/Private/RTSFogOfWarActor.cpp
@@ -119,8 +119,7 @@ void ARTSFogOfWarActor::Tick(float DeltaTime)
 		}
 	}
 
-	UpdateTextureRegions(FogOfWarTexture, 0, 1, FogOfWarUpdateTextureRegion, 256 * 4, (uint32)4, FogOfWarTextureBuffer, false);
-	FogOfWarMaterialInstance->SetTextureParameterValue(FName("VisibilityMask"), FogOfWarTexture);
+	UpdateTextureRegions(FogOfWarTexture, 0, 1, FogOfWarUpdateTextureRegion, TileSize.X * 4, (uint32)4, FogOfWarTextureBuffer, false);
 }
 
 void ARTSFogOfWarActor::SetupVisionInfo(ARTSVisionInfo* InVisionInfo)


### PR DESCRIPTION
The call to UpdateTextureRegions has the tile size hardcoded to 256 which works for the example setup but fails when you either use a different SizePerTile or different world size.

Also removes an unnecessary SetTextureParameterValue every tick.