### PR TITLE
Don't use deprecated API

### DIFF
--- a/Source/RTS/Plugins/RTSPlugin/Source/RTSPlugin/Classes/RTSMinimapWidget.h
+++ b/Source/RTS/Plugins/RTSPlugin/Source/RTSPlugin/Classes/RTSMinimapWidget.h
@@ -3,6 +3,7 @@
 #include "RTSPluginPCH.h"
 
 #include "Blueprint/UserWidget.h"
+#include "Launch/Resources/Version.h" // Included only for IntelliSense.
 
 #include "RTSMinimapWidget.generated.h"
 
@@ -11,6 +12,7 @@ class ARTSMinimapVolume;
 class ARTSPlayerController;
 class ARTSVisionInfo;
 class ARTSVisionVolume;
+class ARTSFogOfWarActor;
 
 
 /**
@@ -80,7 +82,13 @@ public:
 protected:
 	void NativeConstruct() override;
     void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
+
+#if ENGINE_MAJOR_VERSION > 4 || (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= 20)
+	int32 NativePaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const override;
+#else
 	void NativePaint(FPaintContext& InContext) const override;
+#endif
+
 	FReply NativeOnMouseButtonDown(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
 	FReply NativeOnMouseButtonUp(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;
 	FReply NativeOnMouseMove(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent) override;

--- a/Source/RTS/Plugins/RTSPlugin/Source/RTSPlugin/Private/RTSMinimapWidget.cpp
+++ b/Source/RTS/Plugins/RTSPlugin/Source/RTSPlugin/Private/RTSMinimapWidget.cpp
@@ -128,10 +128,26 @@ void URTSMinimapWidget::NativeTick(const FGeometry& MyGeometry, float InDeltaTim
     FogOfWarBrush.SetResourceObject(FogOfWarMaterialInstance);
 }
 
+#if ENGINE_MAJOR_VERSION > 4 || (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= 20)
+int32 URTSMinimapWidget::NativePaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const
+{
+	LayerId = UUserWidget::NativePaint(Args, AllottedGeometry, MyCullingRect, OutDrawElements, LayerId, InWidgetStyle, bParentEnabled);
+
+	FPaintContext Context(AllottedGeometry, MyCullingRect, OutDrawElements, LayerId, InWidgetStyle, bParentEnabled);
+
+	Context.MaxLayer++;
+
+	DrawBackground(Context);
+	DrawUnits(Context);
+	DrawVision(Context);
+	DrawViewFrustum(Context);
+
+	return FMath::Max(LayerId, Context.MaxLayer);
+}
+#else
 void URTSMinimapWidget::NativePaint(FPaintContext& InContext) const
 {
 	UUserWidget::NativePaint(InContext);
-
 	InContext.MaxLayer++;
 
 	DrawBackground(InContext);
@@ -139,6 +155,7 @@ void URTSMinimapWidget::NativePaint(FPaintContext& InContext) const
 	DrawVision(InContext);
 	DrawViewFrustum(InContext);
 }
+#endif
 
 FReply URTSMinimapWidget::NativeOnMouseButtonDown(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
 {


### PR DESCRIPTION
See: https://github.com/EpicGames/UnrealEngine/blob/f509bb2d6c62806882d9a10476f3654cf1ee0634/Engine/Source/Runtime/UMG/Public/Blueprint/UserWidget.h#L1039

Also fixes the compiling error introduced in a172998f96653139aa46313018be7780f11c6ee4