### PR TITLE
#110 - Double click for attack prompts attack outside of allowable range

### DIFF
--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/Combat/RTSAttackComponent.h
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/Combat/RTSAttackComponent.h
@@ -47,6 +47,14 @@ public:
     UFUNCTION(BlueprintPure)
     float GetRemainingCooldown() const;
 
+    /** Set current target of issued attack order. */
+    UFUNCTION(BlueprintCallable)
+    void SetTarget(AActor* Target);
+
+    /** Get current target of issued attack order. Null if target is dead or attack order has been cancelled. */
+    UFUNCTION(BlueprintCallable)
+    AActor* GetTarget() const;
+
 
 	/** Event when the attack cooldown has expired. */
 	UPROPERTY(BlueprintAssignable, Category = "RTS")
@@ -71,4 +79,7 @@ private:
 
     /** Time before the next attack can be used, in seconds. This is shared between attacks.*/
     float RemainingCooldown;
+
+    /** Current target of issued attack order by PawnAIController. */
+    AActor* CurrentTarget;
 };

--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/Combat/RTSAttackComponent.cpp
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/Combat/RTSAttackComponent.cpp
@@ -126,3 +126,13 @@ float URTSAttackComponent::GetRemainingCooldown() const
 {
     return RemainingCooldown;
 }
+
+void URTSAttackComponent::SetTarget(AActor* Target)
+{
+	CurrentTarget = Target;
+}
+
+AActor* URTSAttackComponent::GetTarget() const
+{
+	return CurrentTarget;
+}

--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/RTSPawnAIController.cpp
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/RTSPawnAIController.cpp
@@ -99,6 +99,12 @@ void ARTSPawnAIController::IssueAttackOrder(AActor* Target)
 		return;
 	}
 
+	// Attack order already issued for this target
+	if (Target == AttackComponent->GetTarget())
+	{
+		return;
+	}
+
 	// Update blackboard.
 	SetOrderType(ERTSOrderType::ORDER_Attack);
 	ClearBuildingClass();
@@ -274,6 +280,7 @@ void ARTSPawnAIController::ClearHomeLocation()
 void ARTSPawnAIController::ClearTargetActor()
 {
 	Blackboard->ClearValue(TEXT("TargetActor"));
+	AttackComponent->SetTarget(nullptr);
 }
 
 void ARTSPawnAIController::ClearTargetLocation()
@@ -299,6 +306,7 @@ void ARTSPawnAIController::SetOrderType(const ERTSOrderType OrderType)
 void ARTSPawnAIController::SetTargetActor(AActor* TargetActor)
 {
 	Blackboard->SetValueAsObject(TEXT("TargetActor"), TargetActor);
+	AttackComponent->SetTarget(TargetActor);
 }
 
 void ARTSPawnAIController::SetTargetLocation(const FVector& TargetLocation)


### PR DESCRIPTION
Hi @npruehs,

Fixes npruehs/ue4-rts#110.

This prevents duplicate attack orders from being issued against the same target which in turn would allow attacks from outside the specified attack radius.

Please feel free to suggest edits to this fix as you know your codebase better than I do :)

Your README specifies opening pull requests against the develop branch but that is quite out of date so I've used release/1.0 as the base.