### PR TITLE
Added setters to name, description, portrait components

### DIFF
--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSDescriptionComponent.h
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSDescriptionComponent.h
@@ -20,6 +20,7 @@ public:
     UFUNCTION(BlueprintPure)
     FText GetDescription() const;
 
+    /** Sets the description of the actor. */
     UFUNCTION(BlueprintCallable)
     void SetDescription(const FText& NewDescription);
 

--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSDescriptionComponent.h
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSDescriptionComponent.h
@@ -20,6 +20,9 @@ public:
     UFUNCTION(BlueprintPure)
     FText GetDescription() const;
 
+    UFUNCTION(BlueprintCallable)
+    void SetDescription(const FText& NewDescription);
+
 private:
     /** Description of the actor. */
     UPROPERTY(EditDefaultsOnly, Category = "RTS")

--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSNameComponent.h
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSNameComponent.h
@@ -18,7 +18,7 @@ class REALTIMESTRATEGY_API URTSNameComponent : public UActorComponent
 public:
     /** Gets the name of the actor. */
     UFUNCTION(BlueprintPure)
-    FText GetNameRTS() const;
+    FText GetName() const;
 
     UFUNCTION(BlueprintCallable)
     void SetName(const FText& NewName);

--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSNameComponent.h
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSNameComponent.h
@@ -18,7 +18,10 @@ class REALTIMESTRATEGY_API URTSNameComponent : public UActorComponent
 public:
     /** Gets the name of the actor. */
     UFUNCTION(BlueprintPure)
-    FText GetName() const;
+    FText GetNameRTS() const;
+
+    UFUNCTION(BlueprintCallable)
+    void SetName(const FText& NewName);
 
 private:
     /** Name of the actor. */

--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSNameComponent.h
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSNameComponent.h
@@ -20,6 +20,7 @@ public:
     UFUNCTION(BlueprintPure)
     FText GetName() const;
 
+    /** Sets the name of the actor. */
     UFUNCTION(BlueprintCallable)
     void SetName(const FText& NewName);
 

--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSPortraitComponent.h
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSPortraitComponent.h
@@ -23,6 +23,9 @@ public:
     UFUNCTION(BlueprintPure)
     UTexture2D* GetPortrait() const;
 
+	UFUNCTION(BlueprintCallable)
+    void SetPortrait(UTexture2D* NewPortrait);
+
 private:
 	/** Portrait of the actor. Can be shown in the UI. */
 	UPROPERTY(EditDefaultsOnly, Category = "RTS")

--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSPortraitComponent.h
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Classes/RTSPortraitComponent.h
@@ -23,6 +23,7 @@ public:
     UFUNCTION(BlueprintPure)
     UTexture2D* GetPortrait() const;
 
+	/** Sets the portrait of the actor. */
 	UFUNCTION(BlueprintCallable)
     void SetPortrait(UTexture2D* NewPortrait);
 

--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/RTSDescriptionComponent.cpp
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/RTSDescriptionComponent.cpp
@@ -4,3 +4,8 @@ FText URTSDescriptionComponent::GetDescription() const
 {
     return Description;
 }
+
+void URTSDescriptionComponent::SetDescription(const FText& NewDescription)
+{
+    Description = NewDescription;
+}

--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/RTSNameComponent.cpp
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/RTSNameComponent.cpp
@@ -1,6 +1,6 @@
 #include "RTSNameComponent.h"
 
-FText URTSNameComponent::GetNameRTS() const
+FText URTSNameComponent::GetName() const
 {
     return Name;
 }

--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/RTSNameComponent.cpp
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/RTSNameComponent.cpp
@@ -1,6 +1,11 @@
 #include "RTSNameComponent.h"
 
-FText URTSNameComponent::GetName() const
+FText URTSNameComponent::GetNameRTS() const
 {
     return Name;
+}
+
+void URTSNameComponent::SetName(const FText& NewName)
+{
+    Name = NewName;
 }

--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/RTSPortraitComponent.cpp
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/RTSPortraitComponent.cpp
@@ -7,3 +7,8 @@ UTexture2D* URTSPortraitComponent::GetPortrait() const
 {
     return Portrait;
 }
+
+void URTSPortraitComponent::SetPortrait(UTexture2D* NewPortrait)
+{
+    Portrait = NewPortrait;
+}


### PR DESCRIPTION
Added setters to the components as in my project I construct units from data loaded via the asset manager and needed to change those on the fly.

This has been tested in 4.24-4.25 but there should be no reason it doesn't work on earlier versions.