### PR TITLE
Fix crash when attempting to access pending kill actor

### DIFF
--- a/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/RTSPlayerController.cpp
+++ b/Source/RTSProject/Plugins/RealTimeStrategy/Source/RealTimeStrategy/Private/RTSPlayerController.cpp
@@ -1908,7 +1908,15 @@ void ARTSPlayerController::PlayerTick(float DeltaTime)
 	}
 
 	// Verify selection.
-	int32 DeselectedActors = SelectedActors.RemoveAll([=](AActor* SelectedActor) { return SelectedActor->IsHidden(); });
+	int32 DeselectedActors = SelectedActors.RemoveAll([=](AActor* SelectedActor)
+	{
+		// Validate before accessing due to a crash caused occasionally
+		if(IsValid(SelectedActor))
+		{
+			return SelectedActor->IsHidden();
+		}
+		return false;		
+	});
 
     if (DeselectedActors > 0)
     {


### PR DESCRIPTION
In my project we have units that get upgraded to new ones which spawn a new actor. On occasion it crashes due to the old actor not being valid when it tries to access it here.